### PR TITLE
Check port_open with command getgovernanceinfo

### DIFF
--- a/bin/sentinel.py
+++ b/bin/sentinel.py
@@ -133,7 +133,7 @@ def is_dashd_port_open(dashd):
     # operators if it's not
     port_open = False
     try:
-        info = dashd.rpc_command('getinfo')
+        info = dashd.rpc_command('getgovernanceinfo')
         port_open = True
     except (socket.error, JSONRPCException) as e:
         print("%s" % e)


### PR DESCRIPTION
This should improve performance since `getinfo` is taking more resources to prepare the result than `getgovernanceinfo`.