### PR TITLE
Replace watchdogs with ping

### DIFF
--- a/bin/sentinel.py
+++ b/bin/sentinel.py
@@ -203,7 +203,7 @@ def main():
     # load "gobject list" rpc command data, sync objects into internal database
     perform_dashd_object_sync(dashd)
 
-    if dashd.has_sentinel_ping():
+    if dashd.has_sentinel_ping:
         sentinel_ping(dashd)
     else:
         # delete old watchdog objects, create a new if necessary

--- a/bin/sentinel.py
+++ b/bin/sentinel.py
@@ -59,6 +59,19 @@ def watchdog_check(dashd):
 
     printdbg("leaving watchdog_check")
 
+# ping dashd
+def sentinel_ping(dashd):
+    printdbg("in sentinel_ping")
+
+    # delete expired watchdogs
+    for wd in Watchdog.expired(dashd):
+        printdbg("\tFound expired watchdog [%s], voting to delete" % wd.object_hash)
+        wd.vote(dashd, VoteSignals.delete, VoteOutcomes.yes)
+
+    dashd.rpc_command("sentinelping", config.sentinel_version)
+
+    printdbg("leaving sentinel_ping")
+
 
 def attempt_superblock_creation(dashd):
     import dashlib
@@ -190,8 +203,11 @@ def main():
     # load "gobject list" rpc command data, sync objects into internal database
     perform_dashd_object_sync(dashd)
 
-    # delete old watchdog objects, create a new if necessary
-    watchdog_check(dashd)
+    if dashd.has_sentinel_ping():
+        sentinel_ping(dashd)
+    else:
+        # delete old watchdog objects, create a new if necessary
+        watchdog_check(dashd)
 
     # auto vote network objects as valid/invalid
     # check_object_validity(dashd)

--- a/bin/sentinel.py
+++ b/bin/sentinel.py
@@ -59,6 +59,7 @@ def watchdog_check(dashd):
 
     printdbg("leaving watchdog_check")
 
+
 # ping dashd
 def sentinel_ping(dashd):
     printdbg("in sentinel_ping")

--- a/bin/sentinel.py
+++ b/bin/sentinel.py
@@ -64,12 +64,7 @@ def watchdog_check(dashd):
 def sentinel_ping(dashd):
     printdbg("in sentinel_ping")
 
-    # delete expired watchdogs
-    for wd in Watchdog.expired(dashd):
-        printdbg("\tFound expired watchdog [%s], voting to delete" % wd.object_hash)
-        wd.vote(dashd, VoteSignals.delete, VoteOutcomes.yes)
-
-    dashd.rpc_command("sentinelping", config.sentinel_version)
+    dashd.ping()
 
     printdbg("leaving sentinel_ping")
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -10,7 +10,7 @@ default_sentinel_config = os.path.normpath(
 )
 sentinel_config_file = os.environ.get('SENTINEL_CONFIG', default_sentinel_config)
 sentinel_cfg = DashConfig.tokenize(sentinel_config_file)
-
+sentinel_version = 2
 
 def get_dash_conf():
     home = os.environ.get('HOME')

--- a/lib/config.py
+++ b/lib/config.py
@@ -12,6 +12,7 @@ sentinel_config_file = os.environ.get('SENTINEL_CONFIG', default_sentinel_config
 sentinel_cfg = DashConfig.tokenize(sentinel_config_file)
 sentinel_version = 2
 
+
 def get_dash_conf():
     home = os.environ.get('HOME')
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -10,7 +10,7 @@ default_sentinel_config = os.path.normpath(
 )
 sentinel_config_file = os.environ.get('SENTINEL_CONFIG', default_sentinel_config)
 sentinel_cfg = DashConfig.tokenize(sentinel_config_file)
-sentinel_version = 2
+sentinel_version = "1.0.2"
 min_dashd_proto_version_with_sentinel_ping = 70207
 
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -11,6 +11,7 @@ default_sentinel_config = os.path.normpath(
 sentinel_config_file = os.environ.get('SENTINEL_CONFIG', default_sentinel_config)
 sentinel_cfg = DashConfig.tokenize(sentinel_config_file)
 sentinel_version = 2
+min_dashd_proto_version_with_sentinel_ping = 70207
 
 
 def get_dash_conf():

--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -237,3 +237,7 @@ class DashDaemon():
                 raise e
 
         return epoch
+
+    @property
+    def has_sentinel_ping(self):
+        return self.govinfo['hassentinelping']

--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -240,4 +240,7 @@ class DashDaemon():
 
     @property
     def has_sentinel_ping(self):
-        return self.govinfo['hassentinelping']
+        try:
+            return self.govinfo['hassentinelping']
+        except KeyError:
+            return 0

--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -240,7 +240,6 @@ class DashDaemon():
 
     @property
     def has_sentinel_ping(self):
-        try:
-            return self.govinfo['hassentinelping']
-        except KeyError:
-            return 0
+        getinfo = self.rpc_command('getinfo')
+        return (getinfo['protocolversion'] >= config.min_dashd_proto_version_with_sentinel_ping)
+

--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -242,3 +242,6 @@ class DashDaemon():
     def has_sentinel_ping(self):
         getinfo = self.rpc_command('getinfo')
         return (getinfo['protocolversion'] >= config.min_dashd_proto_version_with_sentinel_ping)
+
+    def ping(self):
+        self.rpc_command('sentinelping', config.sentinel_version)

--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -242,4 +242,3 @@ class DashDaemon():
     def has_sentinel_ping(self):
         getinfo = self.rpc_command('getinfo')
         return (getinfo['protocolversion'] >= config.min_dashd_proto_version_with_sentinel_ping)
-


### PR DESCRIPTION
Rationale: Watchdogs have proved quite problematic. We should be able to replace them by integrating sentinel information into Masternode ping objects. Need to use new rpc call for sentinel to update its timestamp and version.

This requires changes to both dashcore and sentinel (dashcore PR#1491 with the same name). The changes are made in a backward compatible way so that dashcore and sentinel do not necessarily have to be upgraded at the same time. 

Changes  for sentinel:
 check if dashd supports sentinel ping, checking if the governance info has the flag "hassentinelping";
 if ping supported call sentinel ping rpc command on each run and disable watchdog creation, otherwise use current behavior (ie. create watchdogs) 