### PR TITLE
account for updated MN outpoint key

### DIFF
--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -63,7 +63,8 @@ class DashDaemon():
 
         try:
             status = self.rpc_command('masternode', 'status')
-            my_vin = parse_masternode_status_vin(status['vin'])
+            mn_outpoint = status.get('outpoint') or status.get('vin')
+            my_vin = parse_masternode_status_vin(mn_outpoint)
         except JSONRPCException as e:
             pass
 


### PR DESCRIPTION
Key `vin` is changing to `outpoint` in output of `masternode status`