### PR TITLE
[SECURITY] Exception handling in sentinel is too coarse-grained

### DIFF
--- a/lib/models.py
+++ b/lib/models.py
@@ -82,11 +82,14 @@ class GovernanceObject(BaseModel):
             for purged in self.purged_network_objects(list(golist.keys())):
                 # SOMEDAY: possible archive step here
                 purged.delete_instance(recursive=True, delete_nullable=True)
-
-            for item in golist.values():
-                (go, subobj) = self.import_gobject_from_dashd(dashd, item)
         except Exception as e:
-            printdbg("Got an error upon import: %s" % e)
+            printdbg("Got an error while purging: %s" %e)
+
+        for item in golist.values():
+            try:
+                (go, subobj) = self.import_gobject_from_dashd(dashd, item)
+            except Exception as e:
+                printdbg("Got an error upon import: %s" % e)
 
     @classmethod
     def purged_network_objects(self, network_object_hashes):

--- a/lib/models.py
+++ b/lib/models.py
@@ -83,7 +83,7 @@ class GovernanceObject(BaseModel):
                 # SOMEDAY: possible archive step here
                 purged.delete_instance(recursive=True, delete_nullable=True)
         except Exception as e:
-            printdbg("Got an error while purging: %s" %e)
+            printdbg("Got an error while purging: %s" % e)
 
         for item in golist.values():
             try:


### PR DESCRIPTION
Further to our conversation on the forum, @nmarley , let me explain why the previous fix is insufficient

- Consider an exception from an invalid object being thrown somewhere in `import_gobject_from_dashd`
- At this point all processing of the `golist` stops, if you are unlucky, this could happen on the first object and you haven't processed anything.
- Since the exception is caught, execution continues, but sentinel hasn't got a complete picture of the gobject list.
- If the sentinel didn't process a watchdog before the exception was thrown, it will attempt to create one
- This can repeat, stopped only by the rate-limiting in the daemon

In practice this can be abused to trip all masternodes into watchdog expired.