### PR TITLE
ignore pycodestyle E129 error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   - py.test -svv test/unit/
 
   # style guide check
-  - find ./lib ./test ./bin -name \*.py -exec pycodestyle --show-source --ignore=E501,E402,E722 {} +
+  - find ./lib ./test ./bin -name \*.py -exec pycodestyle --show-source --ignore=E501,E402,E722,E129 {} +


### PR DESCRIPTION
... as there's no good way to fix this b/c of conflicting PEP8 rules (under-indent vs over-indent vs same-line indent)

A relevant Github issue is here, where the maintainer seems to not care: https://github.com/PyCQA/pycodestyle/issues/386