### PR TITLE
restrict proposals to 512 bytes

### DIFF
--- a/lib/models.py
+++ b/lib/models.py
@@ -331,7 +331,7 @@ class Proposal(GovernanceClass, BaseModel):
                 return False
 
             # Dash Core restricts proposals to 512 bytes max
-            if len(self.serialise()) >= (self.MAX_DATA_SIZE * 2):
+            if len(self.serialise()) > (self.MAX_DATA_SIZE * 2):
                 printdbg("\tProposal [%s] is too big, returning False" % self.name)
                 return False
 

--- a/lib/models.py
+++ b/lib/models.py
@@ -276,6 +276,9 @@ class Proposal(GovernanceClass, BaseModel):
     payment_amount = DecimalField(max_digits=16, decimal_places=8)
     object_hash = CharField(max_length=64)
 
+    # src/governance-validators.cpp
+    MAX_DATA_SIZE = 512
+
     govobj_type = DASHD_GOVOBJ_TYPES['proposal']
 
     class Meta:
@@ -325,6 +328,11 @@ class Proposal(GovernanceClass, BaseModel):
             # proposal URL has any whitespace
             if (re.search(r'\s', self.url)):
                 printdbg("\tProposal URL [%s] has whitespace, returning False" % self.name)
+                return False
+
+            # Dash Core restricts proposals to 512 bytes max
+            if len(self.serialise()) >= (self.MAX_DATA_SIZE * 2):
+                printdbg("\tProposal [%s] is too big, returning False" % self.name)
                 return False
 
             try:

--- a/test/unit/models/test_proposals.py
+++ b/test/unit/models/test_proposals.py
@@ -282,8 +282,20 @@ def test_approved_and_ranked(go_list_proposals):
 def test_proposal_size(proposal):
     orig = Proposal(**proposal.get_dict())  # make a copy
 
-    # fixture as-is should be valid
+    proposal.url = 'https://testurl.com/'
+    proposal_length_bytes = len(proposal.serialise()) // 2
+
+    # how much space is available in the Proposal
+    extra_bytes = (Proposal.MAX_DATA_SIZE - proposal_length_bytes)
+
+    # fill URL field with max remaining space
+    proposal.url = proposal.url + ('x' * extra_bytes)
+
+    # ensure this is the max proposal size and is valid
+    assert (len(proposal.serialise()) // 2) == Proposal.MAX_DATA_SIZE
     assert proposal.is_valid() is True
 
-    proposal.url = 'https://' + ('x' * 513) + '.com/'
+    # add one more character to URL, Proposal should now be invalid
+    proposal.url = proposal.url + 'x'
+    assert (len(proposal.serialise()) // 2) == (Proposal.MAX_DATA_SIZE + 1)
     assert proposal.is_valid() is False

--- a/test/unit/models/test_proposals.py
+++ b/test/unit/models/test_proposals.py
@@ -277,3 +277,13 @@ def test_approved_and_ranked(go_list_proposals):
 
     assert prop_list[0].object_hash == u'dfd7d63979c0b62456b63d5fc5306dbec451180adee85876cbf5b28c69d1a86c'
     assert prop_list[1].object_hash == u'0523445762025b2e01a2cd34f1d10f4816cf26ee1796167e5b029901e5873630'
+
+
+def test_proposal_size(proposal):
+    orig = Proposal(**proposal.get_dict())  # make a copy
+
+    # fixture as-is should be valid
+    assert proposal.is_valid() is True
+
+    proposal.url = 'https://' + ('x' * 513) + '.com/'
+    assert proposal.is_valid() is False


### PR DESCRIPTION
Related to https://github.com/dashpay/dash/pull/2004 , this is needed for validation rules to stay in sync between Sentinel and Core.