### PR TITLE
 add tests for UTF-8 chars in proposal url, name

### DIFF
--- a/test/unit/models/test_proposals.py
+++ b/test/unit/models/test_proposals.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 import sys
 import os
@@ -142,6 +143,12 @@ def test_proposal_is_valid(proposal):
     proposal.name = 'dean miller 5493'
     assert proposal.is_valid() is False
 
+    proposal.name = 'dean-millerà-5493'
+    assert proposal.is_valid() is False
+
+    proposal.name = 'dean-миллер-5493'
+    assert proposal.is_valid() is False
+
     # binary gibberish
     proposal.name = dashlib.deserialise('22385c7530303933375c75303363375c75303232395c75303138635c75303064335c75303163345c75303264385c75303236615c75303134625c75303163335c75303063335c75303362385c75303266615c75303261355c75303266652f2b5c75303065395c75303164655c75303136655c75303338645c75303062385c75303138635c75303064625c75303064315c75303038325c75303133325c753032333222')
     assert proposal.is_valid() is False
@@ -210,6 +217,12 @@ def test_proposal_is_valid(proposal):
 
     proposal.url = 'http://dashcentral.org/dean-miller 5493'
     assert proposal.is_valid() is False
+
+    proposal.url = 'http://dashcentralisé.org/dean-miller-5493'
+    assert proposal.is_valid() is True
+
+    proposal.url = 'http://dashcentralisé.org/dean-миллер-5493'
+    assert proposal.is_valid() is True
 
     proposal.url = 'https://example.com/resource.ext?param=1&other=2'
     assert proposal.is_valid() is True


### PR DESCRIPTION
This is to stay in line with https://github.com/dashpay/dash/pull/2044, to ensure validation rules are consistent across DashCore and Sentinel.