### PR TITLE
bump minor version for release w/DashCore v12.3

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -10,7 +10,7 @@ default_sentinel_config = os.path.normpath(
 )
 sentinel_config_file = os.environ.get('SENTINEL_CONFIG', default_sentinel_config)
 sentinel_cfg = DashConfig.tokenize(sentinel_config_file)
-sentinel_version = "1.1.0"
+sentinel_version = "1.2.0"
 min_dashd_proto_version_with_sentinel_ping = 70207
 
 


### PR DESCRIPTION
This increments Sentinel to v1.2.0, to be released with Core v12.3.