### PR TITLE
upgrade pycodestyle due to bug in older version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
   - py.test -svv test/unit/
 
   # style guide check
-  - find ./lib ./test ./bin -name \*.py -exec pycodestyle --show-source --ignore=E501,E402,E722,E129 {} +
+  - find ./lib ./test ./bin -name \*.py -exec pycodestyle --show-source --ignore=E501,E402,E722,E129,W503,W504 {} +

--- a/lib/dash_config.py
+++ b/lib/dash_config.py
@@ -15,7 +15,7 @@ class DashConfig():
         f = io.open(filename)
         lines = []
         for line in f:
-            if re.match('^\s*#', line):
+            if re.match(r'^\s*#', line):
                 continue
             lines.append(line)
         f.close()

--- a/lib/dashlib.py
+++ b/lib/dashlib.py
@@ -73,13 +73,13 @@ def elect_mn(**kwargs):
 
 
 def parse_masternode_status_vin(status_vin_string):
-    status_vin_string_regex = re.compile('CTxIn\(COutPoint\(([0-9a-zA-Z]+),\\s*(\d+)\),')
+    status_vin_string_regex = re.compile(r'CTxIn\(COutPoint\(([0-9a-zA-Z]+),\s*(\d+)\),')
 
     m = status_vin_string_regex.match(status_vin_string)
 
     # To Support additional format of string return from masternode status rpc.
     if m is None:
-        status_output_string_regex = re.compile('([0-9a-zA-Z]+)\-(\d+)')
+        status_output_string_regex = re.compile(r'([0-9a-zA-Z]+)-(\d+)')
         m = status_output_string_regex.match(status_vin_string)
 
     txid = m.group(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 peewee==2.8.3
 py==1.4.31
-pycodestyle==2.3.1
+pycodestyle==2.4.0
 pytest==3.0.1
 python-bitcoinrpc==1.0
 simplejson==3.8.2

--- a/test/unit/test_dash_config.py
+++ b/test/unit/test_dash_config.py
@@ -62,7 +62,23 @@ def test_get_rpc_creds():
     assert creds.get('port') == 19998
 
 
-# ensure dash network (mainnet, testnet) matches that specified in config
-# requires running dashd on whatever port specified...
-#
-# This is more of a dashd/jsonrpc test than a config test...
+def test_slurp_config_file():
+    import tempfile
+
+    dash_config = """# basic settings
+#testnet=1 # TESTNET
+server=1
+printtoconsole=1
+txindex=1 # enable transaction index
+"""
+
+    expected_stripped_config = """server=1
+printtoconsole=1
+txindex=1 # enable transaction index
+"""
+
+    with tempfile.NamedTemporaryFile(mode='w') as temp:
+        temp.write(dash_config)
+        temp.flush()
+        conf = DashConfig.slurp_config_file(temp.name)
+        assert conf == expected_stripped_config


### PR DESCRIPTION
Please see individual commits (+ commit messages) for details on each one.

There's a bug in an older version of pycodestyle which is being triggered in Python 3 (only). This PR updates pycodestyle to the most recent version (2.4.0) and adjusts code to adhere to new rules introduced.

This is the warning message thrown in the older version of pycodestyle:

```
lib/python3.7/site-packages/pycodestyle.py:113: FutureWarning: Possible nested set at position 1
  EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
```