### PR TITLE
Only check for "IsSynced" in "mnsync"

### DIFF
--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -95,11 +95,7 @@ class DashDaemon():
 
     def is_synced(self):
         mnsync_status = self.rpc_command('mnsync', 'status')
-        synced = (mnsync_status['IsBlockchainSynced'] and
-                  mnsync_status['IsMasternodeListSynced'] and
-                  mnsync_status['IsWinnersListSynced'] and
-                  mnsync_status['IsSynced'] and
-                  not mnsync_status['IsFailed'])
+        synced = (mnsync_status['IsSynced'] and not mnsync_status['IsFailed'])
         return synced
 
     def current_block_hash(self):


### PR DESCRIPTION
IsSynced implies all other fields to be true as well. At the same time,
IsMasternodeListSynced and IsWinnersListSynced were removed in Dash Core
0.14.0.