### PR TITLE
Update dependency requirements a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,29 +18,29 @@ Sentinel is an autonomous agent for persisting, processing and automating Dash g
 
 ## Install
 
-These instructions cover installing Sentinel on Ubuntu 16.04 / 18.04.
+These instructions cover installing Sentinel on Ubuntu 18.04 / 20.04.
 
 ### Dependencies
 
-Make sure Python version 2.7.x or above is installed:
-
-    python --version
-
-Update system packages and ensure virtualenv is installed:
+Update system package list and install dependencies:
 
     $ sudo apt-get update
-    $ sudo apt-get -y install python-virtualenv
+    $ sudo apt-get -y install git python3 virtualenv
 
-Make sure the local DashCore daemon running is at least version 12.1 (120100)
+Make sure Python version 3.6.x or above is installed:
 
-    $ dash-cli getinfo | grep version
+    python3 --version
+
+Make sure the local DashCore daemon running is at least version 15.0 (150000)
+
+    $ dash-cli getnetworkinfo | jq -r .version
 
 ### Install Sentinel
 
 Clone the Sentinel repo and install Python dependencies.
 
     $ git clone https://github.com/dashpay/sentinel.git && cd sentinel
-    $ virtualenv ./venv
+    $ virtualenv -p $(which python3) ./venv
     $ ./venv/bin/pip install -r requirements.txt
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Make sure Python version 3.6.x or above is installed:
 
     python3 --version
 
-Make sure the local DashCore daemon running is at least version 15.0 (150000)
+Make sure the local DashCore daemon running is at least version 0.15.0.
 
-    $ dash-cli getnetworkinfo | jq -r .version
+    $ dashd --version | head -n1
 
 ### Install Sentinel
 


### PR DESCRIPTION
- only support Python 3
- update for Ubuntu 18.04 and 20.04
- DashCore should be at least 15.0
- update deprecated `getinfo` command for checking version