### PR TITLE
feat: python 3.10 support

### DIFF
--- a/lib/base58.py
+++ b/lib/base58.py
@@ -116,7 +116,7 @@ def get_bcaddress_version(strAddress):
 
 if __name__ == '__main__':
     # Test case (from http://gitorious.org/bitcoin/python-base58.git)
-    assert get_bcaddress_version('15VjRaDX9zpbA8LVnbrCAFzrVzN7ixHNsC') is 0
+    assert get_bcaddress_version('15VjRaDX9zpbA8LVnbrCAFzrVzN7ixHNsC') == 0
     _ohai = 'o hai'.encode('ascii')
     _tmp = b58encode(_ohai)
     assert _tmp == 'DYB3oMS'


### PR DESCRIPTION
Sentinel was failing under Python 3.10, which is annoying because it is the default version in Ubuntu 22.04. This PR:
- Updates the data model to peewee 3 (thanks @nmarley)
- Updates/removes some other dependencies
- Updates Github Action to include Python 3.10 in the matrix, bumps action versions and removes an obsolete caching workaround