### PR TITLE
chore: bump pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 peewee==2.8.3
 py==1.10.0
 pycodestyle==2.4.0
-pytest==3.0.1
+pytest==4.6.11
 python-bitcoinrpc==1.0
 simplejson==3.8.2


### PR DESCRIPTION
4.6.11 is the maximum version supported in the 2.7 line (https://github.com/pytest-dev/pytest/pull/9957/files#diff-652b15931c9619bdfc8929442cdce51dd13d9a3dd4dc798d42958fae008e12c1)