### PR TITLE
test: drop 2.7 and 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        python-version: ["2.7", "3.5", "3.6", "3.8", "3.9"]
+        python-version: ["3.6", "3.8", "3.9"]
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Per comments https://github.com/dashpay/sentinel/pull/81#issuecomment-1141405660 and https://github.com/dashpay/sentinel/pull/83#issuecomment-1141400298, this drops testing of Python 2.7 and 3.5.