### PR TITLE
Remove Python2 urlparse import

### DIFF
--- a/lib/models.py
+++ b/lib/models.py
@@ -15,10 +15,7 @@ import dashd
 from misc import (printdbg, is_numeric)
 import config
 from bitcoinrpc.authproxy import JSONRPCException
-try:
-    import urllib.parse as urlparse
-except ImportError:
-    import urlparse
+import urllib.parse as urlparse
 
 # our mixin
 from governance_class import GovernanceClass


### PR DESCRIPTION
This try/catch was to handle the urlparse lib in both Python 2 and Python 3. Now that Python 2 is not supported, we can simplify the import.