### PR TITLE
Use env vars for dashd JSONRPC connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,19 @@ With all tests passing and crontab setup, Sentinel will stay in sync with dashd 
 
 ## Configuration
 
-An alternative (non-default) path to the `dash.conf` file can be specified in `sentinel.conf`:
+Configuration is done via environment variables. Example:
 
+```sh
+$ RPCUSER=dash RPCPASSWORD=password RPCHOST=127.0.0.1 RPCPORT=19998 ./venv/bin/python bin/sentinel.py
+```
+
+A path to a `dash.conf` file can be specified in `sentinel.conf`:
+
+    # warning: deprecated
     dash_conf=/path/to/dash.conf
+
+This is now deprecated and will be removed in a future version. Users are encouraged to update their configurations to use environment variables instead.
+
 
 ## Troubleshooting
 

--- a/bin/sentinel.py
+++ b/bin/sentinel.py
@@ -105,7 +105,7 @@ def is_dashd_port_open(dashd):
 
 
 def main():
-    dashd = DashDaemon.from_dash_conf(config.dash_conf)
+    dashd = DashDaemon.initialize(config.dash_conf)
     options = process_args()
 
     # print version and return if "--version" is an argument

--- a/lib/config.py
+++ b/lib/config.py
@@ -33,7 +33,10 @@ def get_network():
 
 
 def get_rpchost():
-    return sentinel_cfg.get('rpchost', '127.0.0.1')
+    if 'RPCHOST' in os.environ:
+        return os.environ['RPCHOST']
+    else:
+        return sentinel_cfg.get('rpchost', '127.0.0.1')
 
 
 def sqlite_test_db_name(sqlite_file_path):

--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -11,6 +11,7 @@ from bitcoinrpc.authproxy import AuthServiceProxy, JSONRPCException
 from masternode import Masternode
 from decimal import Decimal
 import time
+from deprecation import deprecated
 
 
 class DashDaemon():
@@ -46,6 +47,8 @@ class DashDaemon():
 
         return self(**jsonrpc_creds)
 
+    @classmethod
+    @deprecated(deprecated_in="1.7", details="Use environment variables to configure Sentinel instead.")
     def from_dash_conf(self, dash_dot_conf):
         from dash_config import DashConfig
         config_text = DashConfig.slurp_config_file(dash_dot_conf)

--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -31,6 +31,21 @@ class DashDaemon():
         return AuthServiceProxy("http://{0}:{1}@{2}:{3}".format(*self.creds))
 
     @classmethod
+    def initialize(self, dash_dot_conf):
+        # TODO: remove the return and raise an exception
+        for var in ['RPCHOST', 'RPCUSER', 'RPCPASSWORD', 'RPCPORT']:
+            if var not in os.environ:
+                return self.from_dash_conf(dash_dot_conf)
+
+        jsonrpc_creds = {}
+
+        jsonrpc_creds['host'] = os.environ['RPCHOST']
+        jsonrpc_creds['user'] = os.environ['RPCUSER']
+        jsonrpc_creds['password'] = os.environ['RPCPASSWORD']
+        jsonrpc_creds['port'] = os.environ['RPCPORT']
+
+        return self(**jsonrpc_creds)
+
     def from_dash_conf(self, dash_dot_conf):
         from dash_config import DashConfig
         config_text = DashConfig.slurp_config_file(dash_dot_conf)

--- a/lib/init.py
+++ b/lib/init.py
@@ -76,7 +76,7 @@ def has_dash_conf():
 
 def has_required_env_vars():
     for var in ['RPCHOST', 'RPCPASSWORD', 'RPCPORT', 'RPCUSER']:
-        if not var in os.environ:
+        if var not in os.environ:
             return False
     return True
 
@@ -107,5 +107,6 @@ def main():
     # deprecation warning
     if not has_required_env_vars() and has_dash_conf():
         print("deprecation warning: JSONRPC credentials should now be set using environment variables. Using dash.conf will be deprecated in the near future.")
+
 
 main()

--- a/lib/init.py
+++ b/lib/init.py
@@ -74,6 +74,13 @@ def has_dash_conf():
     return valid_dash_conf
 
 
+def has_required_env_vars():
+    for var in ['RPCHOST', 'RPCPASSWORD', 'RPCPORT', 'RPCUSER']:
+        if not var in os.environ:
+            return False
+    return True
+
+
 # === begin main
 
 
@@ -93,9 +100,12 @@ def main():
         print("Please ensure correct database configuration.")
         sys.exit(1)
 
-    if not has_dash_conf():
+    if not has_required_env_vars() and not has_dash_conf():
         print("DashCore must be installed and configured, including JSONRPC access in dash.conf")
         sys.exit(1)
 
+    # deprecation warning
+    if not has_required_env_vars() and has_dash_conf():
+        print("deprecation warning: JSONRPC credentials should now be set using environment variables. Using dash.conf will be deprecated in the near future.")
 
 main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
+deprecation==2.1.0
+packaging==21.3
 peewee==2.8.3
 py==1.10.0
 pycodestyle==2.4.0
 pytest==7.0.1
+pyparsing==3.0.9
 python-bitcoinrpc==1.0
 simplejson==3.8.2

--- a/test/unit/models/test_proposals.py
+++ b/test/unit/models/test_proposals.py
@@ -81,7 +81,9 @@ def proposal():
 def test_proposal_is_valid(proposal):
     from dashd import DashDaemon
     import dashlib
-    dashd = DashDaemon.from_dash_conf(config.dash_conf)
+    for var in ['RPCHOST', 'RPCPASSWORD', 'RPCPORT', 'RPCUSER']:
+        os.environ[var] = 'hi'
+    dashd = DashDaemon.initialize(config.dash_conf)
 
     orig = Proposal(**proposal.get_dict())  # make a copy
 
@@ -281,7 +283,9 @@ def test_proposal_is_expired(proposal):
 # deterministic ordering
 def test_approved_and_ranked(go_list_proposals):
     from dashd import DashDaemon
-    dashd = DashDaemon.from_dash_conf(config.dash_conf)
+    for var in ['RPCHOST', 'RPCPASSWORD', 'RPCPORT', 'RPCUSER']:
+        os.environ[var] = 'hi'
+    dashd = DashDaemon.initialize(config.dash_conf)
 
     for item in go_list_proposals:
         (go, subobj) = GovernanceObject.import_gobject_from_dashd(dashd, item)

--- a/test/unit/models/test_superblocks.py
+++ b/test/unit/models/test_superblocks.py
@@ -124,7 +124,9 @@ def superblock():
 
 def test_superblock_is_valid(superblock):
     from dashd import DashDaemon
-    dashd = DashDaemon.from_dash_conf(config.dash_conf)
+    for var in ['RPCHOST', 'RPCPASSWORD', 'RPCPORT', 'RPCUSER']:
+        os.environ[var] = 'hi'
+    dashd = DashDaemon.initialize(config.dash_conf)
 
     orig = Superblock(**superblock.get_dict())  # make a copy
 
@@ -228,7 +230,10 @@ def test_deterministic_superblock_creation(go_list_proposals):
     import dashlib
     import misc
     from dashd import DashDaemon
-    dashd = DashDaemon.from_dash_conf(config.dash_conf)
+    for var in ['RPCHOST', 'RPCPASSWORD', 'RPCPORT', 'RPCUSER']:
+        os.environ[var] = 'hi'
+    dashd = DashDaemon.initialize(config.dash_conf)
+
     for item in go_list_proposals:
         (go, subobj) = GovernanceObject.import_gobject_from_dashd(dashd, item)
 
@@ -247,7 +252,9 @@ def test_deterministic_superblock_creation(go_list_proposals):
 
 def test_deterministic_superblock_selection(go_list_superblocks):
     from dashd import DashDaemon
-    dashd = DashDaemon.from_dash_conf(config.dash_conf)
+    for var in ['RPCHOST', 'RPCPASSWORD', 'RPCPORT', 'RPCUSER']:
+        os.environ[var] = 'hi'
+    dashd = DashDaemon.initialize(config.dash_conf)
 
     for item in go_list_superblocks:
         (go, subobj) = GovernanceObject.import_gobject_from_dashd(dashd, item)


### PR DESCRIPTION
This PR also deprecates parsing dash.conf for the same, and the env vars take precedence if both methods are tried.