### PR TITLE
Replace vin with outpoint

### DIFF
--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -67,19 +67,18 @@ class DashDaemon():
         mnlist = self.rpc_command('masternodelist', 'json')
         return [Masternode(k, v) for (k, v) in mnlist.items()]
 
-    def get_current_masternode_vin(self):
-        from dashlib import parse_masternode_status_vin
+    def get_current_masternode_outpoint(self):
+        from dashlib import parse_masternode_status_outpoint
 
-        my_vin = None
+        my_outpoint = None
 
         try:
             status = self.rpc_command('masternode', 'status')
-            mn_outpoint = status.get('outpoint') or status.get('vin')
-            my_vin = parse_masternode_status_vin(mn_outpoint)
+            my_outpoint = parse_masternode_status_outpoint(status.get('outpoint'))
         except JSONRPCException as e:
             pass
 
-        return my_vin
+        return my_outpoint
 
     def governance_quorum(self):
         # TODO: expensive call, so memoize this
@@ -107,7 +106,7 @@ class DashDaemon():
         return self.govinfo['nextsuperblock']
 
     def is_masternode(self):
-        return not (self.get_current_masternode_vin() is None)
+        return not (self.get_current_masternode_outpoint() is None)
 
     def is_synced(self):
         return self.rpc_command('mnsync', 'status')['IsSynced']
@@ -130,13 +129,13 @@ class DashDaemon():
     def get_my_gobject_votes(self, object_hash):
         import dashlib
         if not self.gobject_votes.get(object_hash):
-            my_vin = self.get_current_masternode_vin()
-            # if we can't get MN vin from output of `masternode status`,
+            my_outpoint = self.get_current_masternode_outpoint()
+            # if we can't get MN outpoint from output of `masternode status`,
             # return an empty list
-            if not my_vin:
+            if not my_outpoint:
                 return []
 
-            (txid, vout_index) = my_vin.split('-')
+            (txid, vout_index) = my_outpoint.split('-')
 
             cmd = ['gobject', 'getcurrentvotes', object_hash, txid, vout_index]
             raw_votes = self.rpc_command(*cmd)
@@ -165,17 +164,17 @@ class DashDaemon():
 
     def we_are_the_winner(self):
         import dashlib
-        # find the elected MN vin for superblock creation...
+        # find the elected MN outpoint for superblock creation...
         current_block_hash = self.current_block_hash()
         mn_list = self.get_masternodes()
         winner = dashlib.elect_mn(block_hash=current_block_hash, mnlist=mn_list)
-        my_vin = self.get_current_masternode_vin()
+        my_outpoint = self.get_current_masternode_outpoint()
 
         # print "current_block_hash: [%s]" % current_block_hash
         # print "MN election winner: [%s]" % winner
-        # print "current masternode VIN: [%s]" % my_vin
+        # print "current masternode outpoint: [%s]" % my_outpoint
 
-        return (winner == my_vin)
+        return (winner == my_outpoint)
 
     def estimate_block_time(self, height):
         import dashlib

--- a/lib/dashlib.py
+++ b/lib/dashlib.py
@@ -45,7 +45,7 @@ def hashit(data):
     return int(hashlib.sha256(data.encode('utf-8')).hexdigest(), 16)
 
 
-# returns the masternode VIN of the elected winner
+# returns the masternode outpoint of the elected winner
 def elect_mn(**kwargs):
     current_block_hash = kwargs['block_hash']
     mn_list = kwargs['mnlist']
@@ -57,33 +57,33 @@ def elect_mn(**kwargs):
 
     candidates = []
     for mn in enabled:
-        mn_vin_hash = hashit(mn.outpoint)
-        diff = mn_vin_hash - block_hash_hash
+        mn_outpoint_hash = hashit(mn.outpoint)
+        diff = mn_outpoint_hash - block_hash_hash
         absdiff = abs(diff)
-        candidates.append({'vin': mn.outpoint, 'diff': absdiff})
+        candidates.append({'outpoint': mn.outpoint, 'diff': absdiff})
 
     candidates.sort(key=lambda k: k['diff'])
 
     try:
-        winner = candidates[0]['vin']
+        winner = candidates[0]['outpoint']
     except:
         winner = None
 
     return winner
 
 
-def parse_masternode_status_vin(status_vin_string):
+def parse_masternode_status_outpoint(status_outpoint_string):
     outpoint_re = re.compile(r'([0-9a-zA-Z]+)-(\d+)')
-    m = outpoint_re.match(status_vin_string)
+    m = outpoint_re.match(status_outpoint_string)
 
     txid = m.group(1)
     index = m.group(2)
 
-    vin = txid + '-' + index
+    outpoint = txid + '-' + index
     if (txid == '0000000000000000000000000000000000000000000000000000000000000000'):
-        vin = None
+        outpoint = None
 
-    return vin
+    return outpoint
 
 
 def create_superblock(proposals, event_block_height, budget_max, sb_epoch_time):
@@ -246,7 +246,7 @@ def parse_raw_votes(raw_votes):
         signal = signal.lower()
         outcome = outcome.lower()
 
-        mn_collateral_outpoint = parse_masternode_status_vin(outpoint)
+        mn_collateral_outpoint = parse_masternode_status_outpoint(outpoint)
         v = {
             'mn_collateral_outpoint': mn_collateral_outpoint,
             'signal': signal,

--- a/test/unit/test_dashy_things.py
+++ b/test/unit/test_dashy_things.py
@@ -36,7 +36,7 @@ def mn_list():
 def mn_status_good():
     # valid masternode status enabled & running
     status = {
-        "vin": "f68a2e5d64f4a9be7ff8d0fbd9059dcd3ce98ad7a19a9260d1d6709127ffac56-1",
+        "outpoint": "f68a2e5d64f4a9be7ff8d0fbd9059dcd3ce98ad7a19a9260d1d6709127ffac56-1",
         "service": "192.168.1.1:19999",
         "pubkey": "yUuAsYCnG5XrjgsGvRwcDqPhgLUnzNfe8L",
         "status": "Masternode successfully started"
@@ -47,7 +47,7 @@ def mn_status_good():
 def mn_status_bad():
     # valid masternode but not running/waiting
     status = {
-        "vin": "0000000000000000000000000000000000000000000000000000000000000000-0",
+        "outpoint": "0000000000000000000000000000000000000000000000000000000000000000-0",
         "service": "0.0.0.0:0",
         "status": "Node just started, not yet activated"
     }
@@ -105,15 +105,15 @@ def test_deterministic_masternode_elections(current_block_hash, mn_list):
     assert winner == '656695ed867e193490261bea74783f0a39329ff634a10a9fb6f131807eeca744-1'
 
 
-def test_parse_masternode_status_vin():
-    from dashlib import parse_masternode_status_vin
+def test_parse_masternode_status_outpoint():
+    from dashlib import parse_masternode_status_outpoint
     status = mn_status_good()
-    vin = parse_masternode_status_vin(status['vin'])
-    assert vin == 'f68a2e5d64f4a9be7ff8d0fbd9059dcd3ce98ad7a19a9260d1d6709127ffac56-1'
+    outpoint = parse_masternode_status_outpoint(status['outpoint'])
+    assert outpoint == 'f68a2e5d64f4a9be7ff8d0fbd9059dcd3ce98ad7a19a9260d1d6709127ffac56-1'
 
     status = mn_status_bad()
-    vin = parse_masternode_status_vin(status['vin'])
-    assert vin is None
+    outpoint = parse_masternode_status_outpoint(status['outpoint'])
+    assert outpoint is None
 
 
 def test_hash_function():


### PR DESCRIPTION
The term `vin` is legacy and not used anymore, `outpoint` is clearer. Specifically this means "collateral outpoint" and refers to the 1000-Dash collateral transaction ID.

This PR should be purely cosmetic and not change any functionality.