### PR TITLE
Remove unused proposal validity check

### DIFF
--- a/lib/models.py
+++ b/lib/models.py
@@ -333,8 +333,7 @@ class Proposal(GovernanceClass, BaseModel):
         ranked = []
         for proposal in query:
             proposal.max_budget = next_superblock_max_budget
-            if proposal.is_valid():
-                ranked.append(proposal)
+            ranked.append(proposal)
 
         return ranked
 


### PR DESCRIPTION
This got missed a while back and will be relevant in the next round of PRs which remove the network variable from Sentinel config. The `is_valid()` method here is now a no-op.