### PR TITLE
Determine default JSONRPC port from testnet value

### DIFF
--- a/lib/dash_config.py
+++ b/lib/dash_config.py
@@ -26,12 +26,23 @@ class DashConfig():
         return data
 
     @classmethod
-    def get_rpc_creds(self, data, network='mainnet'):
+    def get_rpc_creds(self, data):
         # get rpc info from dash.conf
         match = re.findall(r'rpc(user|password|port)=(.*?)$', data, re.MULTILINE)
 
         # python >= 2.7
         creds = {key: value for (key, value) in match}
+
+        # determine default rpc port from testnet= setting in dash.conf
+        network = 'mainnet'
+        testnet_value = re.search(r'testnet=(.*?)$', data, re.MULTILINE)
+        if testnet_value:
+            capture = testnet_value[1].strip()
+            try:
+                if int(capture) != 0:
+                    network = 'testnet'
+            except ValueError as e:
+                network = 'testnet'
 
         # standard Dash defaults...
         default_port = 9998 if (network == 'mainnet') else 19998

--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -52,7 +52,7 @@ class DashDaemon():
     def from_dash_conf(self, dash_dot_conf):
         from dash_config import DashConfig
         config_text = DashConfig.slurp_config_file(dash_dot_conf)
-        creds = DashConfig.get_rpc_creds(config_text, config.network)
+        creds = DashConfig.get_rpc_creds(config_text)
 
         creds[u'host'] = config.rpc_host
 

--- a/test/unit/test_dash_config.py
+++ b/test/unit/test_dash_config.py
@@ -34,7 +34,7 @@ rpcport={rpcport}
 
 def test_get_rpc_creds():
     dash_config = dash_conf()
-    creds = DashConfig.get_rpc_creds(dash_config, 'testnet')
+    creds = DashConfig.get_rpc_creds(dash_config)
 
     for key in ('user', 'password', 'port'):
         assert key in creds
@@ -43,7 +43,7 @@ def test_get_rpc_creds():
     assert creds.get('port') == 29241
 
     dash_config = dash_conf(rpcpassword='s00pers33kr1t', rpcport=8000)
-    creds = DashConfig.get_rpc_creds(dash_config, 'testnet')
+    creds = DashConfig.get_rpc_creds(dash_config)
 
     for key in ('user', 'password', 'port'):
         assert key in creds
@@ -52,7 +52,7 @@ def test_get_rpc_creds():
     assert creds.get('port') == 8000
 
     no_port_specified = re.sub('\nrpcport=.*?\n', '\n', dash_conf(), re.M)
-    creds = DashConfig.get_rpc_creds(no_port_specified, 'testnet')
+    creds = DashConfig.get_rpc_creds(no_port_specified)
 
     for key in ('user', 'password', 'port'):
         assert key in creds


### PR DESCRIPTION
This only affects parsing of the `dash.conf` file, which is deprecated in favor of using env vars.