### PR TITLE
Remove Sentinel network variable

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -28,10 +28,6 @@ def get_dash_conf():
     return dash_conf
 
 
-def get_network():
-    return sentinel_cfg.get('network', 'mainnet')
-
-
 def get_rpchost():
     if 'RPCHOST' in os.environ:
         return os.environ['RPCHOST']
@@ -89,6 +85,5 @@ def get_db_conn():
 
 
 dash_conf = get_dash_conf()
-network = get_network()
 rpc_host = get_rpchost()
 db = get_db_conn()

--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -168,7 +168,7 @@ class DashDaemon():
     def is_govobj_maturity_phase(self):
         # 3-day period for govobj maturity
         maturity_phase_delta = 1662      # ~(60*24*3)/2.6
-        if config.network == 'testnet':
+        if self.network() == 'testnet':
             maturity_phase_delta = 24    # testnet
 
         event_block_height = self.next_superblock_height()

--- a/lib/dashd.py
+++ b/lib/dashd.py
@@ -25,6 +25,7 @@ class DashDaemon():
 
         # memoize calls to some dashd methods
         self.governance_info = None
+        self.blockchain_info = None
         self.gobject_votes = {}
 
     @property
@@ -95,9 +96,30 @@ class DashDaemon():
             self.governance_info = self.rpc_command('getgovernanceinfo')
         return self.governance_info
 
+    @property
+    def blockchaininfo(self):
+        if (not self.blockchain_info):
+            self.blockchain_info = self.rpc_command('getblockchaininfo')
+        return self.blockchain_info
+
     # governance info convenience methods
     def superblockcycle(self):
         return self.govinfo['superblockcycle']
+
+    def network(self):
+        # from dash/src/chainparamsbase.cpp
+        # CBaseChainParams::MAIN = "main";
+        # CBaseChainParams::TESTNET = "test";
+        # CBaseChainParams::DEVNET = "devnet";
+        # CBaseChainParams::REGTEST = "regtest";
+        networks = {
+            'test': 'testnet',
+            'main': 'mainnet',
+        }
+        chain = self.blockchaininfo['chain']
+
+        # returns 'testnet' and 'mainnet' instead of 'test' and 'main'
+        return networks[chain] if chain in networks else chain
 
     def last_superblock_height(self):
         return self.govinfo['lastsuperblock']

--- a/lib/models.py
+++ b/lib/models.py
@@ -147,7 +147,7 @@ class GovernanceObject(BaseModel):
         try:
             newdikt = subdikt.copy()
             newdikt['object_hash'] = object_hash
-            if subclass(**newdikt).is_valid() is False:
+            if subclass(**newdikt).is_valid(dashd) is False:
                 govobj.vote_delete(dashd)
                 return (govobj, None)
 
@@ -283,7 +283,7 @@ class Proposal(GovernanceClass, BaseModel):
 
     # leave for now so this doesn't break the generic govobj validity check
     # above in the import
-    def is_valid(self):
+    def is_valid(self, dashd=None):
         return True
 
     def is_expired(self, superblockcycle=None):
@@ -373,16 +373,20 @@ class Superblock(BaseModel, GovernanceClass):
     class Meta:
         table_name = 'superblocks'
 
-    def is_valid(self):
+    def is_valid(self, dashd=None):
         import dashlib
         import decimal
 
         printdbg("In Superblock#is_valid, for SB: %s" % self.__dict__)
 
+        network = 'mainnet'
+        if dashd is not None:
+            network = dashd.network()
+
         # it's a string from the DB...
         addresses = self.payment_addresses.split('|')
         for addr in addresses:
-            if not dashlib.is_valid_dash_address(addr, config.network):
+            if not dashlib.is_valid_dash_address(addr, network):
                 printdbg("\tInvalid address [%s], returning False" % addr)
                 return False
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -6,3 +6,12 @@ os.environ['RPCPORT'] = 'hi'
 os.environ['RPCUSER'] = 'hi'
 os.environ['SENTINEL_ENV'] = 'test'
 os.environ['SENTINEL_CONFIG'] = os.path.normpath(os.path.join(os.path.dirname(__file__), './test_sentinel.conf'))
+
+sys.path.append(os.path.normpath(os.path.join(os.path.dirname(__file__), '../lib')))
+import dashd
+
+
+class MockDashDaemon(dashd.DashDaemon):
+
+    def network(self):
+        return 'testnet'

--- a/test/test_sentinel.conf
+++ b/test/test_sentinel.conf
@@ -1,3 +1,2 @@
-network=testnet
 db_name=database/sentinel.db
 db_driver=sqlite


### PR DESCRIPTION
Please see individual commits. This PR removes the need for a hard-coded network value in `sentinel.conf`.

I [tried offloading this to dashd](https://github.com/dashpay/sentinel/compare/88b1715...nmarley:sentinel:dashcore-address-validation?expand=1) entirely, but it got complicated b/c address validation is still needed for SB triggers, and the unit tests have no way to call to a dashd instance.