### PR TITLE
ci: add Ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-20.04]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        mkdir ~/.dashcore
+        cp share/dash.conf.example ~/.dashcore/dash.conf
+    - name: Run tests
+      run: |
+        py.test -svv test/unit/
+        black . --check
+
+  test-ubuntu-22:
+    name: Run tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
     - name: Checkout


### PR DESCRIPTION
Just a quick, possibly half-baked PR :see_no_evil: I noticed we hadn't added Ubuntu 22.04 testing back in once we solved the issue with Python 3.10 in #103 and figured I'd put something out there.

Python 3.6 fails on 22.04, so I added a second test job instead of just adding 22.04 to the matrix. Seems better to test what we can than to skip the OS entirely? Didn't investigate if we could make 3.6 work on 22.04 or not.