### PR TITLE
ci: add Ubuntu 18.04 to tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-18.04, ubuntu-20.04]
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:


### PR DESCRIPTION
Ubuntu 18.04 tests pass with all the versions of Python we're testing on 20.04, so this is kind of a freebie. Regardless of what not we decide to do about Python 3.6 support(see discussion in #111), we could include this for now.