### PR TITLE
fix: account for vote weight in getcurrentvotes response

### DIFF
--- a/lib/dashlib.py
+++ b/lib/dashlib.py
@@ -247,7 +247,7 @@ def did_we_vote(output):
 def parse_raw_votes(raw_votes):
     votes = []
     for v in list(raw_votes.values()):
-        (outpoint, ntime, outcome, signal) = v.split(":")
+        (outpoint, ntime, outcome, signal, vote_weight) = v.split(":")
         signal = signal.lower()
         outcome = outcome.lower()
 
@@ -257,6 +257,7 @@ def parse_raw_votes(raw_votes):
             "signal": signal,
             "outcome": outcome,
             "ntime": ntime,
+            "vote_weight": vote_weight,
         }
         votes.append(v)
 


### PR DESCRIPTION
`getcurrentvotes` now returns a "vote weight" at the [end of the string](https://github.com/dashpay/dash/pull/5039/files#diff-6f6f9e4c99f31adec8adcffa30e9aac3ffce07b970458be020ea53ddcc7f83c2.). I don't know what else might be impacted, but I think at least this must be done to parse the response correctly. Other stuff may be required internally. I leave that to the experts :nerd_face: 