### PR TITLE
Fix README instructions for using formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Specifically:
 Please use `black` to format code automatically before opening a PR:
 
 ```sh
-./venv/bin/pip black .
+./venv/bin/black .
 ```
 
 ## License


### PR DESCRIPTION
Seems like the `pip` command got put in by mistake.