### PR TITLE
chore: bump version to 1.7.2

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -10,7 +10,7 @@ default_sentinel_config = os.path.normpath(
 )
 sentinel_config_file = os.environ.get("SENTINEL_CONFIG", default_sentinel_config)
 sentinel_cfg = DashConfig.tokenize(sentinel_config_file)
-sentinel_version = "1.7.1"
+sentinel_version = "1.7.2"
 
 
 def get_dash_conf():


### PR DESCRIPTION
Is 1.7.2 correct or is this a bigger version increase?

- **Fix breaking on getcurrentvotes due to vote weights (#116)**
- docs: update badge in README.md (#114)
- ci: update test.yml branches (#113)
- Fix README instructions for using formatter (#117)
- ci: remove ubuntu-18.04 due to GH action support deprecation (#118)
- chore: bump sentinel version to 1.7.2
