### PR TITLE
feat: show deprecation warning

### DIFF
--- a/lib/init.py
+++ b/lib/init.py
@@ -88,7 +88,6 @@ def has_required_env_vars():
 
 def main():
     print("deprecation warning: Dash Sentinel is deprecated and should be uninstalled. See https://github.com/dashpay/sentinel for details.")
-    sys.exit(1)
 
     install_instructions = "\tpip install -r requirements.txt"
 

--- a/lib/init.py
+++ b/lib/init.py
@@ -87,6 +87,9 @@ def has_required_env_vars():
 
 
 def main():
+    print("deprecation warning: Dash Sentinel is deprecated and should be uninstalled. See https://github.com/dashpay/sentinel for details.")
+    sys.exit(1)
+
     install_instructions = "\tpip install -r requirements.txt"
 
     if not is_valid_python_version():

--- a/lib/init.py
+++ b/lib/init.py
@@ -87,7 +87,9 @@ def has_required_env_vars():
 
 
 def main():
-    print("deprecation warning: Dash Sentinel is deprecated and should be uninstalled. See https://github.com/dashpay/sentinel for details.")
+    print(
+        "deprecation warning: Dash Sentinel is deprecated and should be uninstalled. See https://github.com/dashpay/sentinel for details."
+    )
 
     install_instructions = "\tpip install -r requirements.txt"
 


### PR DESCRIPTION
Possible final release (if necessary). Since Sentinel has been deprecated, there's no need for it to execute any logic other than providing a deprecation notice. I think something like this would do it. Tests blow up as expected.